### PR TITLE
[PR](Architecture): remove raw pointer and fix missing changes from …

### DIFF
--- a/src/ECS/Entity/EntityManager.hpp
+++ b/src/ECS/Entity/EntityManager.hpp
@@ -18,6 +18,7 @@
     #define SRC_ECS_ENTITY_ENTITYMANAGER_HPP_
     #include <iostream>
     #include <vector>
+    #include "Shared/Interface/ECS/IEntity.hpp"
     #include "Shared/Interface/ECS/IEntityManager.hpp"
 
 using Entity = std::size_t;  /// Alias for entity identifiers.

--- a/src/Shared/Interface/Core/IStateManager.hpp
+++ b/src/Shared/Interface/Core/IStateManager.hpp
@@ -8,13 +8,14 @@
 
 #ifndef SRC_SHARED_INTERFACE_CORE_ISTATEMANAGER_HPP_
     #define SRC_SHARED_INTERFACE_CORE_ISTATEMANAGER_HPP_
+    #include <memory>
     #include "Core/IGameState.hpp"
 
 namespace Arcade {
 class IStateManager {
  public:
     virtual ~IStateManager() = default;
-    virtual void changeState(IGameState* newState) = 0;
+    virtual void changeState(std::shared_ptr<IGameState> newState) = 0;
 };
 }  // namespace Arcade
 #endif  // SRC_SHARED_INTERFACE_CORE_ISTATEMANAGER_HPP_

--- a/src/Shared/Interface/ECS/IComponentManager.hpp
+++ b/src/Shared/Interface/ECS/IComponentManager.hpp
@@ -9,17 +9,19 @@
 #ifndef SRC_SHARED_INTERFACE_ECS_ICOMPONENTMANAGER_HPP_
     #define SRC_SHARED_INTERFACE_ECS_ICOMPONENTMANAGER_HPP_
     #include <string>
+    #include <memory>
     #include "Interface/ECS/IComponent.hpp"
-    #include "Models/EntityType.hpp"
+    #include "Interface/ECS/IEntity.hpp"
 
 namespace Arcade {
 class IComponentManager {
  public:
     virtual ~IComponentManager() = default;
-    virtual void registerComponent(Entity entity, IComponent* component) = 0;
-    virtual IComponent* getComponent(Entity entity,
+    virtual void registerComponent(std::shared_ptr<IEntity> entity,
+        std::shared_ptr<IComponent> component) = 0;
+    virtual IComponent* getComponent(std::shared_ptr<IEntity> entity,
         const std::string& componentName) = 0;
-    virtual void removeComponent(Entity entity,
+    virtual void unregisterComponent(std::shared_ptr<IEntity> entity,
         const std::string& componentName) = 0;
 };
 }  // namespace Arcade

--- a/src/Shared/Interface/ECS/IEntity.hpp
+++ b/src/Shared/Interface/ECS/IEntity.hpp
@@ -1,0 +1,20 @@
+// Copyright 2025 <Epitech>
+/*
+** EPITECH PROJECT, 2025
+** B-OOP-400 Arcade
+** File description:
+** Entity Interface
+*/
+
+#ifndef SRC_SHARED_INTERFACE_ECS_IENTITY_HPP_
+    #define SRC_SHARED_INTERFACE_ECS_IENTITY_HPP_
+
+namespace Arcade {
+class IEntity {
+ public:
+    virtual ~IEntity() = default;
+    virtual int getId() const = 0;
+};
+}  // namespace Arcade
+
+#endif  // SRC_SHARED_INTERFACE_ECS_IENTITY_HPP_

--- a/src/Shared/Interface/ECS/IEntityManager.hpp
+++ b/src/Shared/Interface/ECS/IEntityManager.hpp
@@ -10,6 +10,7 @@
     #define SRC_SHARED_INTERFACE_ECS_IENTITYMANAGER_HPP_
     #include <vector>
     #include "Models/EntityType.hpp"
+
 namespace Arcade {
 class IEntityManager {
  public:

--- a/src/Shared/Interface/ECS/ISystemManager.hpp
+++ b/src/Shared/Interface/ECS/ISystemManager.hpp
@@ -8,14 +8,15 @@
 
 #ifndef SRC_SHARED_INTERFACE_ECS_ISYSTEMMANAGER_HPP_
     #define SRC_SHARED_INTERFACE_ECS_ISYSTEMMANAGER_HPP_
+    #include <memory>
     #include "Interface/ECS/ISystem.hpp"
 
 namespace Arcade {
 class ISystemManager {
  public:
     virtual ~ISystemManager() = default;
-    virtual void registerSystem(Arcade::ISystem* system) = 0;
-    virtual void removeSystem(Arcade::ISystem* system) = 0;
+    virtual void registerSystem(std::shared_ptr<Arcade::ISystem> system) = 0;
+    virtual void unregisterSystem(std::shared_ptr<Arcade::ISystem> system) = 0;
     virtual void updateSystems() = 0;
 };
 }  // namespace Arcade

--- a/src/Shared/Interface/Game/IGameModule.hpp
+++ b/src/Shared/Interface/Game/IGameModule.hpp
@@ -16,7 +16,8 @@
 #ifndef SRC_SHARED_INTERFACE_GAME_IGAMEMODULE_HPP_
     #define SRC_SHARED_INTERFACE_GAME_IGAMEMODULE_HPP_
     #include <vector>
-    #include "Models/EntityType.hpp"
+    #include <memory>
+    #include "Interface/ECS/IEntity.hpp"
 
 namespace Arcade {
 /**
@@ -33,7 +34,8 @@ class IGameModule {
     virtual void init() = 0;
     virtual void update(float deltaTime) = 0;
     virtual void stop() = 0;
-    virtual std::vector<Entity> getEntities() const = 0;
+    virtual std::vector<std::shared_ptr<IEntity>>
+        getEntities() const = 0;
     virtual bool isGameOver() const = 0;
     virtual bool hasWon() const = 0;
 };


### PR DESCRIPTION
This pull request includes several changes to improve the memory management and interface consistency across the ECS (Entity Component System) framework by using `std::shared_ptr` for managing entities, components, and systems. Additionally, a new `IEntity` interface was introduced.

Memory management improvements:

* [`src/Shared/Interface/Core/IStateManager.hpp`](diffhunk://#diff-e32c6e7cb1c32577d6e668d5eee85db465930c32fc141c5a8197efb48a1aef8bR11-R18): Changed `changeState` method to use `std::shared_ptr<IGameState>` instead of a raw pointer.
* [`src/Shared/Interface/ECS/IComponentManager.hpp`](diffhunk://#diff-d5840fb95b8eb1d05913f5361208bd03847502e426485f7dfedb7a94e9b294a9R12-R24): Updated methods to use `std::shared_ptr<IEntity>` and `std::shared_ptr<IComponent>` instead of raw pointers.
* [`src/Shared/Interface/ECS/ISystemManager.hpp`](diffhunk://#diff-bac6c421677121c86886f23701630598e6bd2e1dd5e006e46a89b775b292ab02R11-R19): Changed `registerSystem` and `unregisterSystem` methods to use `std::shared_ptr<Arcade::ISystem>` instead of raw pointers.

Interface consistency:

* [`src/Shared/Interface/Game/IGameModule.hpp`](diffhunk://#diff-a7df13572adb30e64bbf479b80f9f9f175e847f98e122a0ab279482559502aebL36-R38): Updated `getEntities` method to return a vector of `std::shared_ptr<IEntity>` instead of a vector of raw entity identifiers.

New interface addition:

* [`src/Shared/Interface/ECS/IEntity.hpp`](diffhunk://#diff-069c9d271d1beb4dd760eabb86983abc7ac39b36340f174a54548d4c458bb53fR1-R20): Added a new `IEntity` interface with a virtual destructor and a pure virtual `getId` method.