### PR TITLE
[FEAT](ModuleInfo): Added ModuleInfo to all dynamic library (thx marin)

### DIFF
--- a/src/Core/Menu/Menu.cpp
+++ b/src/Core/Menu/Menu.cpp
@@ -14,6 +14,7 @@
 #include "Core/Window/Window.hpp"
 #include "Shared/Interface/Display/IDisplayModule.hpp"
 #include "Shared/Models/ColorType.hpp"
+#include "Shared/Models/ModuleInfos.hpp"
 
 namespace Arcade {
 
@@ -168,5 +169,11 @@ void Menu::setScoreManager(std::shared_ptr<ScoreManager> scoreManager) {
 extern "C" {
     Arcade::IMenu* entryPoint() {
         return new Arcade::Menu(nullptr, nullptr);
+    }
+
+    Arcade::ModuleInfos module_infos() {
+        return {"Menu", "IDK",
+            "IDK",
+            "./lib/arcade_menu.so", Arcade::ModuleType::GAME_COMPONENT};
     }
 }

--- a/src/ECS/Components/Position/PositionComponent.cpp
+++ b/src/ECS/Components/Position/PositionComponent.cpp
@@ -8,6 +8,7 @@
 #include "ECS/Components/Position/PositionComponent.hpp"
 #include "Shared/Models/ComponentType.hpp"
 #include "Shared/Interface/IArcadeModule.hpp"
+#include "Shared/Models/ModuleInfos.hpp"
 
 ComponentType PositionComponent::getType() const {
     return ComponentType::POSITION;
@@ -25,5 +26,11 @@ extern "C" {
 
     Arcade::IArcadeModule* entryPoint(void) {
         return new PositionComponent(0, 0);
+    }
+
+    Arcade::ModuleInfos module_infos() {
+        return {"PositionComponent", "IDK",
+            "IDK",
+            "./lib/arcade_position.so", Arcade::ModuleType::GAME_COMPONENT};
     }
 }

--- a/src/ECS/Components/Sprite/SpriteComponent.cpp
+++ b/src/ECS/Components/Sprite/SpriteComponent.cpp
@@ -7,6 +7,7 @@
 */
 #include "ECS/Components/Sprite/SpriteComponent.hpp"
 #include "Shared/Models/ComponentType.hpp"
+#include "Shared/Models/ModuleInfos.hpp"
 
 ComponentType SpriteComponent::getType() const {
     return ComponentType::SPRITE;
@@ -24,5 +25,11 @@ extern "C" {
 
     Arcade::IArcadeModule* entryPoint(void) {
         return new SpriteComponent("");
+    }
+
+    Arcade::ModuleInfos module_infos() {
+        return {"SpriteComponent", "IDK",
+            "IDK",
+            "./lib/arcade_sprite.so", Arcade::ModuleType::GAME_COMPONENT};
     }
 }

--- a/src/ECS/Components/Text/TextComponent.cpp
+++ b/src/ECS/Components/Text/TextComponent.cpp
@@ -7,6 +7,7 @@
 */
 #include "ECS/Components/Text/TextComponent.hpp"
 #include "Shared/Models/ComponentType.hpp"
+#include "Shared/Models/ModuleInfos.hpp"
 
 ComponentType TextComponent::getType() const {
     return ComponentType::TEXT;
@@ -24,5 +25,11 @@ extern "C" {
 
     Arcade::IArcadeModule* entryPoint(void) {
         return new TextComponent("Default Text", 0, 0, Arcade::Color::WHITE);
+    }
+
+    Arcade::ModuleInfos module_infos() {
+        return {"TextComponent", "IDK",
+            "IDK",
+            "./lib/arcade_text.so", Arcade::ModuleType::GAME_COMPONENT};
     }
 }

--- a/src/ECS/Components/Velocity/VelocityComponent.cpp
+++ b/src/ECS/Components/Velocity/VelocityComponent.cpp
@@ -8,6 +8,7 @@
 
 #include "ECS/Components/Velocity/VelocityComponent.hpp"
 #include "Shared/Models/ComponentType.hpp"
+#include "Shared/Models/ModuleInfos.hpp"
 
 ComponentType VelocityComponent::getType() const {
     return ComponentType::VELOCITY;
@@ -25,5 +26,11 @@ extern "C" {
 
     Arcade::IArcadeModule* entryPoint(void) {
         return new VelocityComponent(0, 0);
+    }
+
+    Arcade::ModuleInfos module_infos() {
+        return {"VelocityComponent", "IDK",
+            "IDK",
+            "./lib/arcade_velocity.so", Arcade::ModuleType::GAME_COMPONENT};
     }
 }

--- a/src/Games/Minesweeper/Minesweeper.cpp
+++ b/src/Games/Minesweeper/Minesweeper.cpp
@@ -25,6 +25,7 @@
 #include "ECS/Components/Position/PositionComponent.hpp"
 #include "ECS/Components/Sprite/SpriteComponent.hpp"
 #include "Games/Minesweeper/MinesweeperFactory.hpp"
+#include "Shared/Models/ModuleInfos.hpp"
 
 namespace Arcade {
 
@@ -153,6 +154,12 @@ extern "C" {
 
     void destroy(IGameModule* instance) {
         delete instance;
+    }
+
+    Arcade::ModuleInfos module_infos() {
+        return {"Minesweeper", "IDK",
+            "IDK",
+            "./lib/arcade_minesweeper.so", Arcade::ModuleType::GAME};
     }
 }
 

--- a/src/Games/PacMan/Pacman.cpp
+++ b/src/Games/PacMan/Pacman.cpp
@@ -18,6 +18,7 @@
 #include "Games/PacMan/System/UISystem.hpp"
 #include "ECS/Components/Position/PositionComponent.hpp"
 #include "ECS/Components/Sprite/SpriteComponent.hpp"
+#include "Shared/Models/ModuleInfos.hpp"
 
 namespace Arcade {
 namespace PacMan {
@@ -175,6 +176,12 @@ extern "C" {
 
     void destroy(IGameModule* instance) {
         delete instance;
+    }
+
+    Arcade::ModuleInfos module_infos() {
+        return {"PacMan", "IDK",
+            "IDK",
+            "./lib/arcade_pacman.so", Arcade::ModuleType::GAME};
     }
 }
 

--- a/src/Graphics/Allegro5/Allegro5.cpp
+++ b/src/Graphics/Allegro5/Allegro5.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include "Allegro5/Allegro5.hpp"
 #include "Models/ColorType.hpp"
+#include "Models/ModuleInfos.hpp"
 
 Allegro5::~Allegro5() {
     stop();
@@ -107,5 +108,11 @@ extern "C" {
 
     Arcade::IArcadeModule* entryPoint(void) {
         return new Allegro5();
+    }
+
+    Arcade::ModuleInfos module_infos() {
+        return {"Allegro5", "IDK",
+            "IDK",
+            "./lib/arcade_allegro5.so", Arcade::ModuleType::GRAPHIC_LIB};
     }
 }

--- a/src/Graphics/GTK+/GTK.cpp
+++ b/src/Graphics/GTK+/GTK.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include "GTK+/GTK.hpp"
 #include "Models/ColorType.hpp"
+#include "Models/ModuleInfos.hpp"
 
 GTKModule::GTKModule() : _name("GTK+"), _eventManager(nullptr) {
     gtk_init();
@@ -192,5 +193,11 @@ extern "C" {
 
     Arcade::IArcadeModule* entryPoint(void) {
         return new GTKModule();
+    }
+
+    Arcade::ModuleInfos module_infos() {
+        return {"GTK+", "IDK",
+            "IDK",
+            "./lib/arcade_gtk+.so", Arcade::ModuleType::GRAPHIC_LIB};
     }
 }

--- a/src/Graphics/NCurses/NCurses.cpp
+++ b/src/Graphics/NCurses/NCurses.cpp
@@ -14,6 +14,7 @@
 #include "NCurses/NCurses.hpp"
 #include "NCurses/NCursesColor.hpp"
 #include "Interface/IArcadeModule.hpp"
+#include "Models/ModuleInfos.hpp"
 
 NCursesModule::~NCursesModule() {
     stop();
@@ -231,5 +232,11 @@ extern "C" {
 
     Arcade::IArcadeModule* entryPoint(void) {
         return new NCursesModule();
+    }
+
+    Arcade::ModuleInfos module_infos() {
+        return {"NCurses", "IDK",
+            "IDK",
+            "./lib/arcade_ncurses.so", Arcade::ModuleType::GRAPHIC_LIB};
     }
 }

--- a/src/Graphics/OpenGL/OpenGL.cpp
+++ b/src/Graphics/OpenGL/OpenGL.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <string>
 #include <utility>
+#include "Models/ModuleInfos.hpp"
 
 OpenGLModule::OpenGLModule()
     : _name("OpenGL"), _windowWidth(800), _windowHeight(600), _running(true) {}
@@ -98,5 +99,11 @@ std::pair<size_t, size_t> OpenGLModule::getMousePosition() const {
 extern "C" {
     Arcade::IDisplayModule* entryPoint(void) {
         return new OpenGLModule();
+    }
+
+    Arcade::ModuleInfos module_infos() {
+        return {"OpenGL", "IDK",
+            "IDK",
+            "./lib/arcade_opengl.so", Arcade::ModuleType::GRAPHIC_LIB};
     }
 }

--- a/src/Graphics/SDL/SDL.cpp
+++ b/src/Graphics/SDL/SDL.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include "SDL/SDLColor.hpp"
 #include "Interface/IArcadeModule.hpp"
+#include "Models/ModuleInfos.hpp"
 
 SDLModule::~SDLModule() {
     stop();
@@ -138,4 +139,10 @@ extern "C" __attribute__((destructor)) void fini_sdl(void) { }
 
 extern "C" Arcade::IArcadeModule* entryPoint(void) {
     return new SDLModule();
+}
+
+extern "C" Arcade::ModuleInfos module_infos() {
+    return {"SDL2", "IDK",
+        "IDK",
+        "./lib/arcade_sdl2.so", Arcade::ModuleType::GRAPHIC_LIB};
 }

--- a/src/Graphics/SFML/SFML.cpp
+++ b/src/Graphics/SFML/SFML.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include "SFML/SFMLColor.hpp"
 #include "Interface/IArcadeModule.hpp"
+#include "Models/ModuleInfos.hpp"
 
 SFML::~SFML() {
     _window.reset();
@@ -101,4 +102,10 @@ extern "C" __attribute__((destructor)) void fini_sfml(void) {}
 
 extern "C" Arcade::IArcadeModule* entryPoint(void) {
     return new SFML();
+}
+
+extern "C" Arcade::ModuleInfos module_infos() {
+    return {"SFML", "IDK",
+        "IDK",
+        "./lib/arcade_sfml.so", Arcade::ModuleType::GRAPHIC_LIB};
 }

--- a/src/Shared/Models/ModuleInfos.hpp
+++ b/src/Shared/Models/ModuleInfos.hpp
@@ -1,0 +1,30 @@
+// Copyright 2025 <Epitech>
+/*
+** EPITECH PROJECT, 2025
+** arcade [WSL: Ubuntu]
+** File description:
+** ModuleInfos
+*/
+
+#ifndef SRC_SHARED_MODELS_MODULEINFOS_HPP_
+    #define SRC_SHARED_MODELS_MODULEINFOS_HPP_
+    #include <string>
+
+namespace Arcade {
+
+enum class ModuleType {
+    GAME,
+    GRAPHIC_LIB,
+    GAME_COMPONENT,
+};
+
+struct ModuleInfos {
+    std::string name;
+    std::string description;
+    std::string picturePath;
+    std::string path;
+    ModuleType type;
+};
+}  // namespace Arcade
+
+#endif  // SRC_SHARED_MODELS_MODULEINFOS_HPP_


### PR DESCRIPTION
This pull request introduces a new `ModuleInfos` structure to provide metadata about various modules in the project. The changes include adding the `ModuleInfos` structure and updating several files to include this new structure. 

The most important changes include:

### Addition of `ModuleInfos` structure:
* [`src/Shared/Models/ModuleInfos.hpp`](diffhunk://#diff-89cb744cdcba30a7042d967c8e928dd341ee212d9abf2b7e7bab516d6f1c4258R1-R30): Added new `ModuleInfos` structure to define module metadata, including name, description, picture path, path, and type.

### Updates to include `ModuleInfos`:
* [`src/Core/Menu/Menu.cpp`](diffhunk://#diff-6105f1e32323a1e534bf9d37a57d513e4169100c5a8426423e532e53fad45f5aR17): Included `ModuleInfos` header and added a new `module_infos` function to return metadata for the Menu module. [[1]](diffhunk://#diff-6105f1e32323a1e534bf9d37a57d513e4169100c5a8426423e532e53fad45f5aR17) [[2]](diffhunk://#diff-6105f1e32323a1e534bf9d37a57d513e4169100c5a8426423e532e53fad45f5aR173-R178)
* [`src/ECS/Components/Position/PositionComponent.cpp`](diffhunk://#diff-e8e870a966663af9d423b422b6f0d1c0e556e2e929ff831ecabaf497de7fc2e5R11): Included `ModuleInfos` header and added a new `module_infos` function to return metadata for the PositionComponent module. [[1]](diffhunk://#diff-e8e870a966663af9d423b422b6f0d1c0e556e2e929ff831ecabaf497de7fc2e5R11) [[2]](diffhunk://#diff-e8e870a966663af9d423b422b6f0d1c0e556e2e929ff831ecabaf497de7fc2e5R30-R35)
* [`src/ECS/Components/Sprite/SpriteComponent.cpp`](diffhunk://#diff-2ab20db2fd9683b6f266042dc7f25be5a931b3ff06ef477ca3ab7b3b2ef1dec1R10): Included `ModuleInfos` header and added a new `module_infos` function to return metadata for the SpriteComponent module. [[1]](diffhunk://#diff-2ab20db2fd9683b6f266042dc7f25be5a931b3ff06ef477ca3ab7b3b2ef1dec1R10) [[2]](diffhunk://#diff-2ab20db2fd9683b6f266042dc7f25be5a931b3ff06ef477ca3ab7b3b2ef1dec1R29-R34)
* [`src/ECS/Components/Text/TextComponent.cpp`](diffhunk://#diff-26c4310bcce42381a88156eed0cb40e05fdf16c63d78d9d97e313f06f2647665R10): Included `ModuleInfos` header and added a new `module_infos` function to return metadata for the TextComponent module. [[1]](diffhunk://#diff-26c4310bcce42381a88156eed0cb40e05fdf16c63d78d9d97e313f06f2647665R10) [[2]](diffhunk://#diff-26c4310bcce42381a88156eed0cb40e05fdf16c63d78d9d97e313f06f2647665R29-R34)
* [`src/ECS/Components/Velocity/VelocityComponent.cpp`](diffhunk://#diff-892e917cb31b32dea4992b08a8743e69336501699d64b13c938f64b515701265R11): Included `ModuleInfos` header and added a new `module_infos` function to return metadata for the VelocityComponent module. [[1]](diffhunk://#diff-892e917cb31b32dea4992b08a8743e69336501699d64b13c938f64b515701265R11) [[2]](diffhunk://#diff-892e917cb31b32dea4992b08a8743e69336501699d64b13c938f64b515701265R30-R35)
* [`src/Games/Minesweeper/Minesweeper.cpp`](diffhunk://#diff-3d02a230849e35c96ff369c54b6634bb503727bf9570390bec28b0897fdfd262R28): Included `ModuleInfos` header and added a new `module_infos` function to return metadata for the Minesweeper module. [[1]](diffhunk://#diff-3d02a230849e35c96ff369c54b6634bb503727bf9570390bec28b0897fdfd262R28) [[2]](diffhunk://#diff-3d02a230849e35c96ff369c54b6634bb503727bf9570390bec28b0897fdfd262R158-R163)
* [`src/Games/PacMan/Pacman.cpp`](diffhunk://#diff-4ed6f39a9a21014206343d11d2eb9e25e7427f644c551a3a7187e579064fae0aR21): Included `ModuleInfos` header and added a new `module_infos` function to return metadata for the PacMan module. [[1]](diffhunk://#diff-4ed6f39a9a21014206343d11d2eb9e25e7427f644c551a3a7187e579064fae0aR21) [[2]](diffhunk://#diff-4ed6f39a9a21014206343d11d2eb9e25e7427f644c551a3a7187e579064fae0aR180-R185)
* [`src/Graphics/Allegro5/Allegro5.cpp`](diffhunk://#diff-7372f0c7b588007235ed67e96a4dae31d2b7419b874ec857bcff93edde94262bR15): Included `ModuleInfos` header and added a new `module_infos` function to return metadata for the Allegro5 module. [[1]](diffhunk://#diff-7372f0c7b588007235ed67e96a4dae31d2b7419b874ec857bcff93edde94262bR15) [[2]](diffhunk://#diff-7372f0c7b588007235ed67e96a4dae31d2b7419b874ec857bcff93edde94262bR112-R117)
* [`src/Graphics/GTK+/GTK.cpp`](diffhunk://#diff-d5824a4c9bf74499068e3ed4e32e24734f58d251de1f90272a819b5dbade6e91R15): Included `ModuleInfos` header and added a new `module_infos` function to return metadata for the GTK+ module. [[1]](diffhunk://#diff-d5824a4c9bf74499068e3ed4e32e24734f58d251de1f90272a819b5dbade6e91R15) [[2]](diffhunk://#diff-d5824a4c9bf74499068e3ed4e32e24734f58d251de1f90272a819b5dbade6e91R197-R202)
* [`src/Graphics/NCurses/NCurses.cpp`](diffhunk://#diff-41143f46785d67e0ebb4e1c84d060c0bf0da6ed12fd4074514f342e6faf3d076R17): Included `ModuleInfos` header and added a new `module_infos` function to return metadata for the NCurses module. [[1]](diffhunk://#diff-41143f46785d67e0ebb4e1c84d060c0bf0da6ed12fd4074514f342e6faf3d076R17) [[2]](diffhunk://#diff-41143f46785d67e0ebb4e1c84d060c0bf0da6ed12fd4074514f342e6faf3d076R236-R241)
* [`src/Graphics/OpenGL/OpenGL.cpp`](diffhunk://#diff-3023290c7be6c220e782ac1561eb8a5cf7f7d8cee9641d977f9dc840051dcc78R13): Included `ModuleInfos` header and added a new `module_infos` function to return metadata for the OpenGL module. [[1]](diffhunk://#diff-3023290c7be6c220e782ac1561eb8a5cf7f7d8cee9641d977f9dc840051dcc78R13) [[2]](diffhunk://#diff-3023290c7be6c220e782ac1561eb8a5cf7f7d8cee9641d977f9dc840051dcc78R103-R108)
* [`src/Graphics/SDL/SDL.cpp`](diffhunk://#diff-3d3b6983cb376c86422b5866f328563441c77a0af73a9d6768334af138cdbc3cR18): Included `ModuleInfos` header and added a new `module_infos` function to return metadata for the SDL2 module. [[1]](diffhunk://#diff-3d3b6983cb376c86422b5866f328563441c77a0af73a9d6768334af138cdbc3cR18) [[2]](diffhunk://#diff-3d3b6983cb376c86422b5866f328563441c77a0af73a9d6768334af138cdbc3cR143-R148)
* [`src/Graphics/SFML/SFML.cpp`](diffhunk://#diff-1fc915e39e2ca38b6c298ddcf1701b24147ae7c9854e7e788a93fd523943cb59R16): Included `ModuleInfos` header and added a new `module_infos` function to return metadata for the SFML module. [[1]](diffhunk://#diff-1fc915e39e2ca38b6c298ddcf1701b24147ae7c9854e7e788a93fd523943cb59R16) [[2]](diffhunk://#diff-1fc915e39e2ca38b6c298ddcf1701b24147ae7c9854e7e788a93fd523943cb59R106-R111)