### PR TITLE
[FIX](Qt5): Adapted Qt5 to new architecture

### DIFF
--- a/src/Graphics/Qt5/Qt5.cpp
+++ b/src/Graphics/Qt5/Qt5.cpp
@@ -179,6 +179,22 @@ void Qt5Module::refreshScreen() {
     });
 }
 
+void Qt5Module::drawDrawable(const Arcade::DrawableComponent &drawable) {
+    if (!drawable.isVisible)
+        return;
+
+    if (drawable.shouldRenderAsText()) {
+        drawText(drawable.text, static_cast<int>(drawable.posX),
+            static_cast<int>(drawable.posY), drawable.color);
+    } else if (drawable.shouldRenderAsTexture()) {
+        drawTexture(static_cast<int>(drawable.posX),
+            static_cast<int>(drawable.posY), drawable.path);
+    } else if (drawable.shouldRenderAsCharacter()) {
+        drawEntity(static_cast<int>(drawable.posX),
+            static_cast<int>(drawable.posY), drawable.character);
+    }
+}
+
 void Qt5Module::drawEntity(int x, int y, char symbol) {
     // Optional implementation
 }

--- a/src/Graphics/Qt5/Qt5.hpp
+++ b/src/Graphics/Qt5/Qt5.hpp
@@ -173,6 +173,10 @@ class Qt5Module : public Arcade::IDisplayModule {
     void threadMain();
     void executeCommand(std::function<void()> command);
     void executeCommandAndWait(std::function<void()> command);
+    void drawEntity(int x, int y, char symbol);
+    void drawTexture(int x, int y, const std::string &textureId);
+    void drawText(const std::string &text, int x, int y,
+        Arcade::Color color);
 
  public:
     Qt5Module() : _name("Qt5"), _running(false),
@@ -182,10 +186,7 @@ class Qt5Module : public Arcade::IDisplayModule {
     void stop() override;
     void clearScreen() override;
     void refreshScreen() override;
-    void drawEntity(int x, int y, char symbol) override;
-    void drawTexture(int x, int y, const std::string &textureId) override;
-    void drawText(const std::string &text, int x, int y,
-        Arcade::Color color) override;
+    void drawDrawable(const Arcade::DrawableComponent& drawable) override;
     void pollEvents() override;
     bool isOpen() const override;
     const std::string& getName() const override;


### PR DESCRIPTION
This pull request introduces a new method to handle drawing different types of drawable components in the `Qt5Module` class, along with some related refactoring to simplify the code.

### Major Changes:

* Added `drawDrawable` method to handle drawing different types of drawable components based on their properties. (`src/Graphics/Qt5/Qt5.cpp`)
* Removed individual `drawEntity`, `drawTexture`, and `drawText` methods from the public interface of `Qt5Module` and replaced them with the `drawDrawable` method. (`src/Graphics/Qt5/Qt5.hpp`)

### Refactoring:

* Moved the definitions of `drawEntity`, `drawTexture`, and `drawText` methods to the private section of the `Qt5Module` class to be used internally by the new `drawDrawable` method. (`src/Graphics/Qt5/Qt5.hpp`)