### PR TITLE
80 fix ncurses display after json parsing change

### DIFF
--- a/src/Graphics/NCurses/NCurses.cpp
+++ b/src/Graphics/NCurses/NCurses.cpp
@@ -143,7 +143,9 @@ void NCursesModule::drawEntity(int x, int y, char symbol) {
 void NCursesModule::drawDrawable(const Arcade::DrawableComponent &drawable) {
     if (!drawable.isVisible)
         return;
-    if (drawable.text.size() == 1) {
+    if (drawable.shouldRenderAsText()) {
+        drawText(drawable.text, drawable.posX, drawable.posY, drawable.color);
+    } else if (drawable.shouldRenderAsCharacter()) {
         drawEntity(drawable.posX, drawable.posY, drawable.character);
     }
 }

--- a/src/Graphics/NCurses/NCurses.cpp
+++ b/src/Graphics/NCurses/NCurses.cpp
@@ -145,6 +145,8 @@ void NCursesModule::drawDrawable(const Arcade::DrawableComponent &drawable) {
         return;
     if (drawable.shouldRenderAsText()) {
         drawText(drawable.text, drawable.posX, drawable.posY, drawable.color);
+    } else if (drawable.shouldRenderAsTexture()) {
+        drawEntity(drawable.posX, drawable.posY, drawable.character);
     } else if (drawable.shouldRenderAsCharacter()) {
         drawEntity(drawable.posX, drawable.posY, drawable.character);
     }


### PR DESCRIPTION
This pull request includes changes to the `NCursesModule::drawDrawable` method in the `src/Graphics/NCurses/NCurses.cpp` file to improve how drawable components are rendered based on their properties.

Rendering improvements:

* [`src/Graphics/NCurses/NCurses.cpp`](diffhunk://#diff-41143f46785d67e0ebb4e1c84d060c0bf0da6ed12fd4074514f342e6faf3d076L146-R150): Updated the `drawDrawable` method to use new conditional checks (`shouldRenderAsText`, `shouldRenderAsTexture`, and `shouldRenderAsCharacter`) for determining how to render drawable components. This change ensures that text, textures, and characters are rendered appropriately based on their specific properties.

this is a partial fix to have a menu
the game fix will be fix in another PR